### PR TITLE
feat: add RSS fallback for news fetching when GoogleNews fails

### DIFF
--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -3,6 +3,8 @@ from newspaper import Article
 from urllib.parse import urlparse, urlunparse
 import logging
 import re
+import feedparser
+import re
 
 logging.basicConfig(level=logging.ERROR)
 
@@ -29,7 +31,9 @@ def fetch_latest_news_with_content(topic="India", count=3):
     for item in news:
         title = item.get('title', 'No Title')
         raw_link = item.get('link', '')
-        clean_link = clean_url(raw_link)
+
+        #clean_link = clean_url(raw_link)
+        clean_link = raw_link  # ⚠️ disable aggressive cleaning for now
 
         print(f"📰 {title}")
         print(f"🔗 {clean_link}\n")
@@ -41,15 +45,45 @@ def fetch_latest_news_with_content(topic="India", count=3):
             content = article.text.strip()
 
             if content:
-                print("📝 Content:")
+                print("📝 Content fetched:\n")
                 print(content[:500] + "...\n")  # Show content preview
                 final_combined_content += content + "\n\n"
             else:
                 print("⚠️ Content not found.\n")
+
         except Exception as e:
             logging.error(f"❌ Error fetching article content from {clean_link}: {e}")
             print("⚠️ Failed to extract article content.\n")
 
         print("=" * 100)
 
+    # FALLBACK TRIGGER
+    if not final_combined_content.strip():
+        print("⚠️ Primary source failed. Switching to RSS...\n")
+        return fetch_rss_news(topic, count)
+
     return final_combined_content.strip()
+
+def clean_html(raw_html):
+    """Remove HTML tags from RSS description"""
+    clean = re.compile('<.*?>')
+    return re.sub(clean, '', raw_html)
+
+def fetch_rss_news(topic="India", count=3):
+    print(f"\n📡 Falling back to RSS for: {topic}\n")
+
+    url = f"https://news.google.com/rss/search?q={topic}&hl=en-IN&gl=IN&ceid=IN:en"
+    feed = feedparser.parse(url)
+
+    final_content = ""
+
+    for entry in feed.entries[:count]:
+        title = entry.title
+        summary = clean_html(entry.summary)
+
+        print(f"📰 {title}")
+        print(f"📝 {summary[:200]}...\n")
+
+        final_content += f"{title}. {summary}\n\n"
+
+    return final_content.strip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ librosa
 opencv-contrib-python>=4.2.0.34
 coqui-tts[server]
 pywebview
+feedparser
+re

--- a/test_news.py
+++ b/test_news.py
@@ -1,0 +1,11 @@
+from modules.text_generation import fetch_latest_news_with_content
+
+if __name__ == "__main__":
+    topic = input("Enter topic: ")
+    count = int(input("Enter count: "))
+
+    news = fetch_latest_news_with_content(topic, count)
+
+    print("\n" + "="*50)
+    print("🧪 FINAL OUTPUT:\n")
+    print(news[:1500])


### PR DESCRIPTION
feat: implement RSS fallback for news fetching

- Added Google News RSS parser using feedparser
- Fallback triggers when primary scraping fails or returns empty content
- Disabled aggressive URL cleaning to prevent broken links